### PR TITLE
Downgrade hasonefield to be compatible with linkfield

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "dnadesign/silverstripe-youtube-embed": "^0.2.0",
         "gorriecoe/silverstripe-link": "^1.2.4",
         "silverstripe/vendor-plugin": "^1.0",
-        "silvershop/silverstripe-hasonefield" : "^3.0.1"
+        "silvershop/silverstripe-hasonefield" : "^2.1"
     },
     "extra": {
         "installer-name": "silverstripe-elemental-carousel",


### PR DESCRIPTION
Made the code a bit more generic, so it can be more easily customised. And made sure the frames have a height by default, otherwise we can see the images by default.